### PR TITLE
Add CreateInvite endpoint

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,7 +3,9 @@ module github.com/cs130-w22/Group-A3/backend
 go 1.16
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/labstack/echo/v4 v4.6.3
 	github.com/lib/pq v1.10.4
+	github.com/stretchr/testify v1.7.0
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -44,6 +46,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 h1:Hir2P/De0WpUhtrKGGjvSb2YxUgyZ7EFOSLIcSSpiwE=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/backend/handler/class.go
+++ b/backend/handler/class.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Create a class in the backend.
+func CreateClass(cc echo.Context) error {
+	c := cc.(*Context)
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := c.Bind(&body); err != nil || body.Name == "" {
+		return c.NoContent(http.StatusBadRequest)
+	}
+
+	// Confirm that the user is a professor (and exists).
+	professor := false
+	if err := c.Conn.QueryRowContext(c, `
+	SELECT professor
+	FROM Accounts
+	WHERE id = $1
+	`, c.Claims.UserID).Scan(&professor); err != nil || !professor {
+		return c.NoContent(http.StatusUnauthorized)
+	}
+
+	classId := 0
+	err := c.Conn.QueryRowContext(c, `
+	INSERT INTO Classes (name, owner)
+	VALUES ($1, $2)
+	RETURNING id
+	`, body.Name, c.Claims.UserID).Scan(&classId)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	return c.JSON(http.StatusCreated, echo.Map{
+		"id": classId,
+	})
+}

--- a/backend/handler/class_test.go
+++ b/backend/handler/class_test.go
@@ -1,0 +1,101 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cs130-w22/Group-A3/backend/handler"
+	"github.com/cs130-w22/Group-A3/backend/jwt"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateClass(t *testing.T) {
+	t.Run("missingContentTypeHeader", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		rec := httptest.NewRecorder()
+		cc := e.NewContext(req, rec)
+		c := &handler.Context{
+			Context: cc,
+		}
+		if assert.NoError(t, handler.CreateClass(c)) {
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		}
+	})
+	t.Run("missingBody", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		cc := e.NewContext(req, rec)
+		c := &handler.Context{
+			Context: cc,
+		}
+		if assert.NoError(t, handler.CreateClass(c)) {
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		}
+	})
+	t.Run("missingPerms", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		userId := uint(1)
+		className := "myclass"
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{ "name": "`+className+`" }`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		cc := e.NewContext(req, rec)
+		c := &handler.Context{
+			Context: cc,
+			Claims: &jwt.Claims{
+				UserID: userId,
+			},
+		}
+
+		connection, err := db.Conn(c)
+		require.NoError(t, err)
+		c.Conn = connection
+
+		mock.ExpectQuery("SELECT").WithArgs(userId).WillReturnRows(sqlmock.NewRows([]string{"professor"}).AddRow(false))
+		if assert.NoError(t, handler.CreateClass(c)) {
+			assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		}
+	})
+	t.Run("correctPerms", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		userId := uint(1)
+		className := "myclass"
+		newClassId := 1
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{ "name": "`+className+`" }`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		cc := e.NewContext(req, rec)
+		c := &handler.Context{
+			Context: cc,
+			Claims: &jwt.Claims{
+				UserID: userId,
+			},
+		}
+
+		connection, err := db.Conn(c)
+		require.NoError(t, err)
+		c.Conn = connection
+
+		mock.ExpectQuery("SELECT").WithArgs(userId).WillReturnRows(sqlmock.NewRows([]string{"professor"}).AddRow(true))
+		mock.ExpectQuery("INSERT INTO Classes").WithArgs(className, userId).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(newClassId))
+		assert.NoError(t, handler.CreateClass(c))
+	})
+}

--- a/backend/schemas/2-accounts.sql
+++ b/backend/schemas/2-accounts.sql
@@ -84,7 +84,7 @@ CREATE TABLE IF NOT EXISTS ClassMembers (
 -- Valid invite codes to classes.
 CREATE TABLE IF NOT EXISTS Invites (
   -- ID of the invite (code that is used on user side).
-  id uuid DEFAULT uuid_generate_v4(),
+  id uuid DEFAULT uuid_generate_v4() NOT NULL,
 
   -- Class this invite is associated to.
   invites_to INT NOT NULL,
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS Invites (
   expires TIMESTAMPTZ NOT NULL,
 
   -- User that created this invite.
-  created_by INT,
+  created_by INT NOT NULL,
 
   PRIMARY KEY (id),
   FOREIGN KEY (invites_to) REFERENCES Classes (id),


### PR DESCRIPTION
This adds a `CreateInvite` endpoint to the backend, allowing professors to create invite codes for classes they own. API is in accordance with the [README specification](https://github.com/cs130-w22/Group-A3/blob/main/backend/README.md#post-classclass_idinvite).

I am still writing tests.

Closes #47.