### PR TITLE
Scaffold assignment submission

### DIFF
--- a/backend/handler/assignment.go
+++ b/backend/handler/assignment.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Upload a file to the server, spawning a new submission job.
+func UploadSubmission(cc echo.Context) error {
+	c := cc.(*Context)
+
+	classId, assignmentId := c.Get("classId"), c.Get("assignmentId")
+	submittedFile, err := c.FormFile("file")
+
+	file, err := submittedFile.Open()
+	defer file.Close()
+
+	return c.NoContent(http.StatusCreated)
+}


### PR DESCRIPTION
Implements a dummy endpoint for student work upload. In order to make it actually operate, the grading subsystem has got to be done, hence a dependency on #17.