### PR TITLE
QOL for frontend, information-rich landing.

### DIFF
--- a/backend/handler/class.go
+++ b/backend/handler/class.go
@@ -109,6 +109,15 @@ func CreateClass(cc echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 
+	// Insert into class members.
+	_, err = c.Conn.ExecContext(c, `
+	INSERT INTO ClassMembers (user_id, class_id, status)
+	VALUES ($1, $2, $3)
+	`, c.Claims.UserID, classId, "ta")
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
 	return c.JSON(http.StatusCreated, echo.Map{
 		"id": classId,
 	})

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -19,5 +19,10 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint"]
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {
+    "eqeqeq": "error",
+    "yoda": "error",
+    "react/jsx-key": "error"
+  }
 }

--- a/frontend/src/AccountCreation/SignUpForm.tsx
+++ b/frontend/src/AccountCreation/SignUpForm.tsx
@@ -108,7 +108,6 @@ const SignUpForm = ({ mode }: { mode: "professor" | "student" }) => {
         username: target.uid.value,
         password: target.password.value,
         type: mode,
-        courseName: target?.courseName?.value,
       }),
     })
       .then((r) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { useCookies } from "react-cookie";
+
+import { userContext } from "./Context/UserContext";
 
 import Login from "./Login";
 import CreateAccount from "./AccountCreation/CreateAccount";
@@ -7,9 +10,7 @@ import ClassView from "./ClassView/ClassView";
 import AssignmentView from "./AssignmentView/AssignmentView";
 import ClassStatsView from "./ClassStatsView/ClassStatsView";
 import ClassListView from "./ClassListView/ClassListView";
-
-import { userContext } from "./Context/UserContext";
-import { useCookies } from "react-cookie";
+import Me from "./Me";
 
 const defaultUser = {
   user: {
@@ -24,28 +25,13 @@ function App() {
     <userContext.Provider value={defaultUser}>
       <Router>
         <Routes>
-          <Route path="/">
-            {!cookies.jwt ? (
-              <Route index element={<Login />} />
-            ) : (
-              <Route index element={<ClassView />} />
-            )}
-          </Route>
-          <Route path="/create">
-            <Route index element={<CreateAccount />} />
-          </Route>
-          <Route path="/class">
-            <Route index element={<ClassView />} />
-          </Route>
-          <Route path="/class/assignment">
-            <Route index element={<AssignmentView />} />
-          </Route>
-          <Route path="/class/classstats">
-            <Route index element={<ClassStatsView />} />
-          </Route>
-          <Route path="/class/classlist">
-            <Route index element={<ClassListView />} />
-          </Route>
+          <Route path="/" element={cookies.jwt ? <Me /> : <Login />} />
+
+          <Route path="/create" element={<CreateAccount />} />
+          <Route path="/class" element={<ClassView />} />
+          <Route path="/class/assignment" element={<AssignmentView />} />
+          <Route path="/class/classstats" element={<ClassStatsView />} />
+          <Route path="/class/classlist" element={<ClassListView />} />
         </Routes>
       </Router>
     </userContext.Provider>

--- a/frontend/src/Me.tsx
+++ b/frontend/src/Me.tsx
@@ -15,7 +15,7 @@ import { Link } from "react-router-dom";
 import JoinClassModal from "./Modal/JoinClassModal";
 import CreateClassModal from "./Modal/CreateClassModal";
 
-import { createClass, joinClass } from "./api";
+import { createClass, getMe, joinClass } from "./api";
 
 export default function Me() {
   const [cookies, setCookies] = useCookies(["jwt"]);
@@ -38,25 +38,12 @@ export default function Me() {
 
   // Make a request on component mount to fetch user information.
   useEffect(() => {
-    fetch(`http://localhost:8080/class/me`, {
-      method: "get",
-      mode: "cors",
-      headers: {
-        Authorization: cookies.jwt,
-      },
-    })
-      .then((r) => {
-        if (r.status !== 200)
-          throw new Error(
-            `Failed to get user data: ${r.statusText}. Is the server running?`
-          );
-        return r.json();
-      })
-      .then((j) => {
-        setData(j);
-        console.log(j);
-      })
-      .catch((newErr) => setErrors((errors) => [newErr, ...errors]));
+    getMe(
+      cookies.jwt,
+      null,
+      (data) => setData(data),
+      (newErr) => setErrors((errors) => [newErr, ...errors])
+    );
   }, [cookies.jwt]);
 
   // Catch errors before render.

--- a/frontend/src/Me.tsx
+++ b/frontend/src/Me.tsx
@@ -1,0 +1,192 @@
+import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+
+import Container from "react-bootstrap/Container";
+import Col from "react-bootstrap/Col";
+import Row from "react-bootstrap/Row";
+import Card from "react-bootstrap/Card";
+import ProgressBar from "react-bootstrap/ProgressBar";
+import Stack from "react-bootstrap/Stack";
+import Alert from "react-bootstrap/Alert";
+import Spinner from "react-bootstrap/Spinner";
+import Button from "react-bootstrap/Button";
+
+import { Link } from "react-router-dom";
+
+export default function Me(props: { view?: boolean }) {
+  const [cookies, setCookies] = useCookies(["jwt"]);
+  const removeCookies = () => {
+    setCookies("jwt", "");
+  };
+
+  const [data, setData] = useState<{
+    professor?: boolean;
+    username?: string;
+    assignments?: Array<string>;
+    classes?: Array<string>;
+  }>({});
+  const [errors, setErrors] = useState<Array<Error>>([]);
+
+  // Make a request on component mount to fetch user information.
+  useEffect(() => {
+    fetch(`http://localhost:8080/class/me`, {
+      method: "get",
+      mode: "cors",
+      headers: {
+        Authorization: cookies.jwt,
+      },
+    })
+      .then((r) => {
+        if (r.status !== 200)
+          throw new Error(
+            `Failed to get user data: ${r.statusText}. Is the server running?`
+          );
+        return r.json();
+      })
+      .then((j) => {
+        setData(j);
+      })
+      .catch((newErr) => setErrors((errors) => [newErr, ...errors]));
+  }, [cookies.jwt]);
+
+  // Catch errors before render.
+  if (errors.length !== 0) {
+    return (
+      <Container>
+        {errors.map((err, idx) => (
+          <Alert key={idx} variant="warning">
+            {err}
+          </Alert>
+        ))}
+      </Container>
+    );
+  }
+
+  // If we're loading...
+  if (!data) {
+    return (
+      <Container>
+        <Spinner animation="border" variant="primary" />
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <Stack direction="vertical" gap={3}>
+        <Header username={data?.username} removeCookies={removeCookies} />
+
+        {data?.professor && (
+          <>
+            <h2>Professor Tools</h2>
+            <Stack direction="horizontal">
+              <Card>
+                <Card.Body>
+                  <Card.Title>Create a class</Card.Title>
+                </Card.Body>
+              </Card>
+            </Stack>
+          </>
+        )}
+
+        <h2>Classes</h2>
+        <Stack direction="horizontal" gap={3}>
+          {data?.classes?.map((k, idx) => (
+            <ClassCard key={idx} />
+          ))}
+          <ClassCard name={"CS 130"} />
+        </Stack>
+
+        <h2>Upcoming Assignments</h2>
+        <Stack direction="vertical" gap={3}>
+          {data?.assignments?.map((k, idx) => (
+            <AssignmentCard key={idx} name={"hi"} />
+          ))}
+          <AssignmentCard classId="CS 130" name="Homework 1" grade={50} />
+          <AssignmentCard classId="CS 130" name="Homework 2" grade={75} />
+          <AssignmentCard classId="CS 130" name="Homework 3" grade={100} />
+        </Stack>
+      </Stack>
+    </Container>
+  );
+}
+
+function Header({
+  removeCookies,
+  username,
+}: {
+  removeCookies: () => void;
+  username?: string;
+}) {
+  return (
+    <Stack direction="horizontal">
+      <h2>Welcome, {username}</h2>
+      <div className="ms-auto">
+        <Button
+          onClick={removeCookies}
+          variant="primary"
+          size="lg"
+          type="button"
+        >
+          Log Out
+        </Button>
+      </div>
+    </Stack>
+  );
+}
+
+function AssignmentCard({
+  id,
+  classId,
+  name,
+  dueDate,
+  grade,
+}: {
+  id?: number;
+  classId?: string;
+  name?: string;
+  dueDate?: Date;
+  grade?: number;
+}) {
+  return (
+    <Link
+      to={`/class/assignment/${id}`}
+      style={{ textDecoration: "none", color: "inherit" }}
+    >
+      <Card>
+        <Card.Body>
+          <Card.Title>
+            {classId} - {name}
+          </Card.Title>
+          <Card.Subtitle className="mb-2 text-muted">
+            {`Due: ${dueDate}`}
+          </Card.Subtitle>
+          <Container>
+            <Row>
+              <Col>Grade: </Col>
+              <Col xs={11}>
+                <ProgressBar now={grade} label={`${grade}%`} />
+              </Col>
+            </Row>
+          </Container>
+        </Card.Body>
+      </Card>
+    </Link>
+  );
+}
+
+function ClassCard({ id, name }: { id?: string; name?: string }) {
+  return (
+    <Link
+      to={`/class/${id}`}
+      style={{ textDecoration: "none", color: "inherit" }}
+    >
+      <Card>
+        <Card.Body>
+          <Card.Title>{name}</Card.Title>
+          <Card.Subtitle>Owner Name</Card.Subtitle>
+        </Card.Body>
+      </Card>
+    </Link>
+  );
+}

--- a/frontend/src/Modal/CreateClassModal.tsx
+++ b/frontend/src/Modal/CreateClassModal.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import Form from "react-bootstrap/Form";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import { Spinner } from "react-bootstrap";
+
+interface CreateClassModalProps {
+  show?: boolean;
+  loading?: boolean;
+  onHide: () => void;
+  onSubmit: (className: string) => void;
+}
+
+const CreateClassModal = ({
+  show,
+  loading,
+  onHide,
+  onSubmit,
+}: CreateClassModalProps) => (
+  <Modal show={show} onHide={onHide}>
+    <Modal.Header closeButton>
+      <Modal.Title>Create a class</Modal.Title>
+    </Modal.Header>
+    <Form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const target = e.currentTarget as typeof e.currentTarget & {
+          name: { value: string };
+        };
+        onSubmit(target.name.value);
+      }}
+    >
+      <Modal.Body>
+        <Form.Group controlId="formName">
+          <Form.Label>Name</Form.Label>
+          <Form.Control type="text" name="name" />
+        </Form.Group>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button type="submit">
+          <Spinner
+            as="span"
+            size="sm"
+            role="status"
+            aria-hidden="true"
+            animation="border"
+          />
+          Submit
+        </Button>
+      </Modal.Footer>
+    </Form>
+  </Modal>
+);
+
+export default CreateClassModal;

--- a/frontend/src/Modal/JoinClassModal.tsx
+++ b/frontend/src/Modal/JoinClassModal.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import Form from "react-bootstrap/Form";
+import Modal from "react-bootstrap/Modal";
+import Button from "react-bootstrap/Button";
+import { Spinner } from "react-bootstrap";
+
+interface JoinClassModalProps {
+  show?: boolean;
+  loading?: boolean;
+  onHide: () => void;
+  onSubmit: (inviteCode: string, callback: () => void) => void;
+}
+
+const JoinClassModal = ({
+  show,
+  loading,
+  onHide,
+  onSubmit,
+}: JoinClassModalProps) => {
+  const [complete, setComplete] = useState(false);
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Join a class</Modal.Title>
+      </Modal.Header>
+      <Form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const target = e.currentTarget as typeof e.currentTarget & {
+            inviteCode: { value: string };
+          };
+          onSubmit(target.inviteCode.value, () => setComplete(true));
+        }}
+      >
+        <Modal.Body>
+          <Form.Group controlId="formInviteCode">
+            <Form.Control type="text" name="inviteCode" />
+          </Form.Group>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button type="submit" variant={complete ? "success" : "primary"}>
+            {loading && (
+              <Spinner
+                as="span"
+                size="sm"
+                role="status"
+                aria-hidden="true"
+                animation="border"
+              />
+            )}
+            Submit
+          </Button>
+        </Modal.Footer>
+      </Form>
+    </Modal>
+  );
+};
+
+export default JoinClassModal;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,68 +5,9 @@
  * `Promise<T>` type.
  */
 
-const BACKEND_URL = "http://localhost:8080/";
+const BACKEND_URL = "http://localhost:8080";
 
-/**
- * Log in as the given user, minting a new JWT for use in future
- * transactions against the backend.
- *
- * @param username Username for the new account
- * @param password Password for the new account
- * @param onSuccess Fired on a successful return.
- * @param onFailure Fired when the request fails or the response is unfavorable.
- */
-function login(
-  username: string,
-  password: string,
-  onSuccess: (token: string) => void,
-  onFailure: (message: string) => void
-) {
-  fetch(`${BACKEND_URL}/login`, {
-    method: "POST",
-    mode: "cors",
-    body: JSON.stringify({
-      username,
-      password,
-    }),
-  })
-    .then((response) => response.json())
-    .then((json) => onSuccess(json?.token))
-    .catch(onFailure);
-}
-
-/**
- * Create a new user account, with the provided username, password
- * and account type.
- *
- * @param username Username for the new account.
- * @param password Password for the new account.
- * @param accountType Whether the user is a professor or student.
- * @param onSuccess Fired on a successful return.
- * @param onFailure Fired when the request fails or the response is unfavorable.
- */
-function createUser(
-  username: string,
-  password: string,
-  accountType: "student" | "professor",
-  onSuccess: (token: string) => void,
-  onFailure: (message: string) => void
-) {
-  fetch(`${BACKEND_URL}/user`, {
-    method: "POST",
-    mode: "cors",
-    body: JSON.stringify({
-      username,
-      password,
-      type: accountType,
-    }),
-  })
-    .then((r) => r.json())
-    .then((j) => onSuccess(j?.token))
-    .catch(onFailure);
-}
-
-interface AssignmentData {
+export interface AssignmentData {
   name: string;
   dueDate: Date;
   points: number;
@@ -86,7 +27,7 @@ interface AssignmentData {
  * @param onSuccess Fired on success.
  * @param onFailure Fired on failure.
  */
-function getAssignment(
+export function getAssignment(
   token: string,
   classId: string,
   assignmentId: string,
@@ -105,7 +46,7 @@ function getAssignment(
     .catch(onFailure);
 }
 
-interface ClassData {
+export interface ClassData {
   name: string;
   assignments: Array<{
     id: number;
@@ -127,7 +68,7 @@ interface ClassData {
  * @param onSuccess Fired on success.
  * @param onFailure Fired on failure.
  */
-function getClass(
+export function getClass(
   token: string,
   classId: string,
   onSuccess: (data: ClassData) => void,
@@ -155,7 +96,7 @@ function getClass(
  * @param onSuccess Fired on success with the new invite code.
  * @param onFailure Fired on failure with a message.
  */
-function createInvite(
+export function createInvite(
   token: string,
   classId: string,
   validUntil: Date,
@@ -187,7 +128,7 @@ function createInvite(
  * @param onSuccess Fired on successful request.
  * @param onFailure Fired on failed request.
  */
-function dropStudent(
+export function dropStudent(
   token: string,
   classId: string,
   studentId: string,
@@ -214,7 +155,8 @@ function dropStudent(
 
 /**
  * Upload a submission for an assignment to the backend for
- * grading.
+ * grading. This endpoint is a special case, since it uses FormData instead
+ * of a standard JSON body.
  *
  * @param token Authorization token as returned by a login or user creation.
  * @param assignmentId Assignment ID to submit to.
@@ -223,7 +165,7 @@ function dropStudent(
  *                  for monitoring live submission results.
  * @param onFailure Fired when the request fails.
  */
-function uploadSubmission(
+export function uploadSubmission(
   token: string,
   classId: string,
   assignmentId: string,
@@ -247,4 +189,112 @@ function uploadSubmission(
     .catch(onFailure);
 }
 
-export * from ".";
+export type AuthorizedEndpoint<P, R> = (
+  token: string,
+  params: P,
+  onSuccess: (result: R) => void,
+  onFailure: (error: Error) => void
+) => void;
+export type UnauthorizedEndpoint<P, R> = (
+  params: P,
+  onSuccess: (result: R) => void,
+  onFailure: (error: Error) => void
+) => void;
+
+// TODO: make uriGenerator parition parameters into URI values and the corresponding body.
+function authorized<T, R>(
+  uriGenerator: (params: T) => string,
+  statusOk = 200,
+  expectJSON = true,
+  method: "post" | "get" = "post"
+): AuthorizedEndpoint<T, R> {
+  return (
+    token: string,
+    params: T,
+    onSuccess: (result: R) => void,
+    onFailure: (error: Error) => void
+  ) => {
+    fetch(`${BACKEND_URL}${uriGenerator(params)}`, {
+      method,
+      mode: "cors",
+      headers: {
+        Authorization: token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params),
+    })
+      .then((r) => {
+        if (r.status !== statusOk) throw new Error(r.statusText);
+        if (expectJSON) return r.json();
+      })
+      .then(onSuccess)
+      .catch(onFailure);
+  };
+}
+
+function unauthorized<T, R>(
+  uriGenerator: (params: T) => string,
+  statusOk = 200,
+  expectJSON = true,
+  method: "post" | "get" = "post"
+): UnauthorizedEndpoint<T, R> {
+  return (
+    params: T,
+    onSuccess: (result: R) => void,
+    onFailure: (error: Error) => void
+  ) => {
+    fetch(`${BACKEND_URL}${uriGenerator(params)}`, {
+      method,
+      mode: "cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params),
+    })
+      .then((r) => {
+        if (r.status !== statusOk) throw new Error(r.statusText);
+        if (expectJSON) return r.json();
+      })
+      .then(onSuccess)
+      .catch(onFailure);
+  };
+}
+
+/**
+ * Create a new user account, with the provided username, password
+ * and account type.
+ *
+ * @param username Username for the new account.
+ * @param password Password for the new account.
+ * @param accountType Whether the user is a professor or student.
+ * @param onSuccess Fired on a successful return.
+ * @param onFailure Fired when the request fails or the response is unfavorable.
+ */
+export const createUser = unauthorized<
+  { username: string; password: string; type: "student" | "professor" },
+  { token: string }
+>(() => "/user", 201);
+
+/**
+ * Log in as the given user, minting a new JWT for use in future
+ * transactions against the backend.
+ *
+ * @param username Username for the new account
+ * @param password Password for the new account
+ * @param onSuccess Fired on a successful return.
+ * @param onFailure Fired when the request fails or the response is unfavorable.
+ */
+export const login = unauthorized<
+  { username: string; password: string },
+  { token: string }
+>(() => "/login");
+
+export const createClass = authorized<{ name: string }, { id: string }>(
+  () => "/class",
+  201
+);
+
+export const joinClass = authorized<{ inviteCode: string }, void>(
+  () => "/class/join",
+  204
+);

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,6 +49,7 @@ export type AuthorizedEndpoint<P, R> = (
   onSuccess: (result: R) => void,
   onFailure: (error: Error) => void
 ) => void;
+
 export type UnauthorizedEndpoint<P, R> = (
   params: P,
   onSuccess: (result: R) => void,
@@ -56,7 +57,9 @@ export type UnauthorizedEndpoint<P, R> = (
 ) => void;
 
 /**
- * Create an endpoint function that partitions its input using `uriGenerator`.
+ * Create an authorized endpoint function that partitions its input using `uriGenerator`.
+ * The generated function will require passage of an authorization token.
+ *
  * All requests, by default, throw an error if the status code is not 200,
  * use a JSON body, and are of method POST.
  *
@@ -111,6 +114,18 @@ function authorized<T, R>(
   };
 }
 
+/**
+ * Create an endpoint function that partitions its input using `uriGenerator`.
+ * All requests, by default, throw an error if the status code is not 200,
+ * use a JSON body, and are of method POST.
+ *
+ * @param uriGenerator Generator function parsing the input type `T` into a URI against the backend (beginning with '/')
+ *                     and the object to send as the body of the request, if any.
+ * @param statusOk Range of status codes to accept the response.
+ * @param expectJSON Whether the function should expect a JSON body in response.
+ * @param method Method to use against the backend.
+ * @returns A new function.
+ */
 function unauthorized<T, R>(
   uriGenerator: (params: T) => [string, unknown],
   statusOk = 200,
@@ -273,4 +288,24 @@ export const createInvite = authorized<
  */
 const dropStudent = authorized<{ classId: string; studentId: string }, void>(
   ({ classId, studentId }) => [`/class/${classId}/drop`, { studentId }]
+);
+
+interface UserInformation {
+  professor?: boolean;
+  username?: string;
+  assignments?: Array<string>;
+  classes?: Array<{
+    id: number;
+    name: string;
+  }>;
+}
+
+/**
+ * Get information about a student.
+ */
+export const getMe = authorized<null, UserInformation>(
+  () => [`/class/me`, null],
+  200,
+  true,
+  "get"
 );


### PR DESCRIPTION
Adds a new view to the frontend, `<Me />` to summarize all information for both students and professors, conditionally rendering based on their permissions. It has some boilerplate in it right now, but if the database is populated, it should render right.

Additionally, fixes a bug in `SignUpForm.tsx` and makes a few small QOL changes to enforce some pet peeves with ESLint. Specifically, `yoda`, `eqeqeq`, and `react/jsx-key`.

## Changes
* Strict ESLint.
* Flatten route declarations in App.tsx.
* Add Me.tsx, combining the important bits of ClassView + ClassListView + AssignmentView. This page generates based on the /class/me endpoint.
* Better API declarations. Generated dynamically through two handy functions in `api.ts`.

## API Example

Writing a new API function is really easy. You just call either `authorized<T, R>()` or `unauthorized<T, R>()`. Both generate functions of the following forms, respectively:

```ts
export type AuthorizedEndpoint<P, R> = (
  token: string,
  params: P,
  onSuccess: (result: R) => void,
  onFailure: (error: Error) => void
) => void;

export type UnauthorizedEndpoint<P, R> = (
  params: P,
  onSuccess: (result: R) => void,
  onFailure: (error: Error) => void
) => void;
```

Here is the declaration of the `createClass` binding:

```ts
/**
 * Get information about a student.
 */
export const getMe = authorized<null, UserInformation>(
  () => [`/class/me`, null],
  200,
  true,
  "get"
);
```

And here's an example of using it from `Me.tsx`:

```tsx
// Make a request on component mount to fetch user information.
useEffect(() => {
  getMe(
    cookies.jwt,
    null,
    (data) => setData(data),
    (newErr) => setErrors((errors) => [newErr, ...errors])
  );
}, [cookies.jwt]);
```

## Screenshots

### Student View

![limited ui](https://user-images.githubusercontent.com/7704542/156484542-35ffc68b-412a-4171-a4a9-2a4b1b3b4e88.png)

### Professor View

![administrative ui](https://user-images.githubusercontent.com/7704542/156484586-b031983d-9d22-418c-8159-264d4bc9bb62.png)

### View

https://user-images.githubusercontent.com/7704542/156671405-bc99d750-9c55-4f42-9d14-2f52657c7405.mp4
